### PR TITLE
Remove hard dependency on benchfella

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule ExFix.Mixfile do
 
   defp deps do
     [{:calendar, "~> 0.17.3"},
-     {:benchfella, "~> 0.3.0"},
+     {:benchfella, "~> 0.3.0", only: :dev},
     #  {:ex_doc, "~> 0.14", only: :dev, runtime: false},
      {:excoveralls, "~> 0.7", only: :test},
      {:dialyxir, "~> 0.5", only: [:dev], runtime: false},


### PR DESCRIPTION
I think it should  be enough to only have it available in dev and not make dependents install it as well :)