### PR TITLE
Add option to validate SendingTime

### DIFF
--- a/lib/ex_fix/parser.ex
+++ b/lib/ex_fix/parser.ex
@@ -13,8 +13,8 @@ defmodule ExFix.Parser do
   @doc """
   Parse full message
   """
-  def parse(data, dictionary, expected_seqnum \\ nil, validate \\ true) do
-    with %InMessage{valid: true} = msg1 <- parse1(data, dictionary, expected_seqnum, validate),
+  def parse(data, dictionary, expected_seqnum \\ nil, validate \\ true, validate_sending_time \\ true) do
+    with %InMessage{valid: true} = msg1 <- parse1(data, dictionary, expected_seqnum, validate, validate_sending_time),
          msg2 <- parse2(msg1) do
       msg2
     end
@@ -23,9 +23,9 @@ defmodule ExFix.Parser do
   @doc """
   Parse - stage1
   """
-  def parse1(data, dictionary, expected_seqnum \\ nil, validate \\ true)
+  def parse1(data, dictionary, expected_seqnum \\ nil, validate \\ true, validate_sending_time \\ true)
 
-  def parse1(<<"8=FIXT.1.1", @soh, "9=", rest::binary>>, dictionary, expected_seqnum, validate) do
+  def parse1(<<"8=FIXT.1.1", @soh, "9=", rest::binary>>, dictionary, expected_seqnum, validate, _validate_sending_time) do
     [str_len, rest1] = :binary.split(rest, <<@soh>>)
     {len, _} = Integer.parse(str_len)
 
@@ -64,7 +64,7 @@ defmodule ExFix.Parser do
     end
   end
 
-  def parse1(<<"8=", _rest::binary>> = orig_msg, _dictionary, _expected_seqnum, _validate) do
+  def parse1(<<"8=", _rest::binary>> = orig_msg, _dictionary, _expected_seqnum, _validate, _validate_sending_time) do
     %InMessage{
       valid: false,
       msg_type: nil,
@@ -75,7 +75,7 @@ defmodule ExFix.Parser do
     }
   end
 
-  def parse1(data, _dictionary, _expected_seqnum, _validate) do
+  def parse1(data, _dictionary, _expected_seqnum, _validate, _validate_sending_time) do
     %InMessage{
       valid: false,
       msg_type: nil,

--- a/lib/ex_fix/session.ex
+++ b/lib/ex_fix/session.ex
@@ -224,6 +224,7 @@ defmodule ExFix.Session do
           config: %SessionConfig{
             name: session_name,
             validate_incoming_message: validate,
+          validate_sending_time: validate_sending_time,
             log_incoming_msg: log_incoming_msg,
             dictionary: dictionary
           },
@@ -239,7 +240,8 @@ defmodule ExFix.Session do
         <<extra_bytes::binary, data::binary>>,
         dictionary,
         expected_seqnum,
-        validate
+      validate,
+      validate_sending_time
       )
 
     case msg.valid do
@@ -717,6 +719,10 @@ defmodule ExFix.Session do
     |> :crypto.strong_rand_bytes()
     |> Base.encode64()
     |> binary_part(0, len)
+  end
+
+  defp validate_sending_time(_session_name, %Session{config: %SessionConfig{validate_sending_time: false}}, _msg, _expected_seqnum) do
+    :ok
   end
 
   defp validate_sending_time(session_name, %Session{config: config, out_lastseq: out_lastseq} = session, %InMessage{fields: fields, other_msgs: other}, expected_seqnum) do

--- a/lib/ex_fix/session_config.ex
+++ b/lib/ex_fix/session_config.ex
@@ -23,6 +23,7 @@ defmodule ExFix.SessionConfig do
             reconnect_interval: 15,
             reset_on_logon: true,
             validate_incoming_message: true,
+            validate_sending_time: true,
             transport_mod: :gen_tcp,
             transport_options: [],
             time_service: nil,


### PR DESCRIPTION
This commit introduces a new configuration option `validate_sending_time` to `ExFix.SessionConfig`. When set to `false`, the validation of the SendingTime (tag 52) field in incoming messages will be skipped.

This provides flexibility for scenarios where SendingTime accuracy is not critical or is handled by other systems, potentially improving message processing performance.

The following changes were made:
- Added `validate_sending_time` (boolean, default: true) to `ExFix.SessionConfig`.
- Modified `ExFix.Session.validate_sending_time/5` to respect this new config.
- Updated `ExFix.Parser.parse1/5` and `ExFix.Parser.parse/5` to accept and pass down the `validate_sending_time` parameter.
- Adjusted `ExFix.Session.handle_incoming_data/2` to pass the `validate_sending_time` setting from the session config to the parser.
- Added new benchmark cases in `ExFixBench` to compare parsing performance with and without SendingTime validation.